### PR TITLE
🔴 Fix: 3 Critical Security Issues (JWT, Error Exposure, Upload Validation)

### DIFF
--- a/blog-backend/src/main/java/com/fonsi13/blogbackend/config/security/JwtService.java
+++ b/blog-backend/src/main/java/com/fonsi13/blogbackend/config/security/JwtService.java
@@ -3,7 +3,6 @@ package com.fonsi13.blogbackend.config.security;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -72,7 +71,10 @@ public class JwtService {
     }
 
     private Key getSignInKey() {
-        byte[] keyBytes = Decoders.BASE64.decode(secretKey); // Decodificamos la clave
-        return Keys.hmacShaKeyFor(secretKey.getBytes());
-}
+        byte[] keyBytes = secretKey.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        if (keyBytes.length < 32) {
+            throw new IllegalArgumentException("JWT_SECRET debe tener al menos 32 caracteres (256 bits) para HS256");
+        }
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
 }

--- a/blog-backend/src/main/java/com/fonsi13/blogbackend/controllers/StorageController.java
+++ b/blog-backend/src/main/java/com/fonsi13/blogbackend/controllers/StorageController.java
@@ -11,24 +11,57 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Set;
+
 @RestController
 @RequestMapping("api/v1/storage")
 @RequiredArgsConstructor
 public class StorageController {
 
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp");
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/gif", "image/webp"
+    );
+
     private final StorageService storageService;
 
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<String>> uploadImage(@RequestParam("file")MultipartFile file){
-        // Valider que sea una imagen
-        if (!file.getContentType().startsWith("image/")){
+    public ResponseEntity<ApiResponse<String>> uploadImage(@RequestParam("file") MultipartFile file) {
+        // Validar que el archivo no esté vacío
+        if (file.isEmpty()) {
             return ResponseEntity.badRequest()
-                    .body(ApiResponse.error("Solo se permiten archivos de imagen"));
+                    .body(ApiResponse.error("El archivo está vacío"));
+        }
+
+        // Validar tamaño máximo (5MB)
+        if (file.getSize() > MAX_FILE_SIZE) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("El archivo excede el tamaño máximo permitido (5MB)"));
+        }
+
+        // Validar Content-Type (puede ser null si el cliente no lo envía)
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType)) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("Tipo de archivo no permitido. Solo se permiten: JPG, PNG, GIF, WEBP"));
+        }
+
+        // Validar extensión del archivo original
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !hasAllowedExtension(originalFilename)) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("Extensión de archivo no permitida. Solo se permiten: jpg, jpeg, png, gif, webp"));
         }
 
         String imageUrl = storageService.uploadImage(file);
-
         return ResponseEntity.ok(ApiResponse.success("Imagen subida correctamente", imageUrl));
     }
 
+    private boolean hasAllowedExtension(String filename) {
+        int dotIndex = filename.lastIndexOf('.');
+        if (dotIndex == -1) return false;
+        String extension = filename.substring(dotIndex + 1).toLowerCase();
+        return ALLOWED_EXTENSIONS.contains(extension);
+    }
 }

--- a/blog-backend/src/main/resources/application.properties
+++ b/blog-backend/src/main/resources/application.properties
@@ -43,6 +43,10 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.starttls.required=true
 
+# File Upload Limits
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB
+
 # App Configuration
 app.name=${APP_NAME:Blog Fonsi}
 app.frontend.url=${APP_FRONTEND_URL:http://localhost:5173}


### PR DESCRIPTION
## Summary
- **JwtService**: Fixed inconsistent key derivation — `getSignInKey()` decoded Base64 into a variable it never used, then used raw bytes instead. Added 256-bit minimum key length validation for HS256.
- **GlobalExceptionHandler**: Removed `ex.getMessage()` from client responses to prevent information disclosure (OWASP A01:2021). Errors are now logged server-side with slf4j.
- **StorageController**: Added 5MB file size limit, null Content-Type check, file extension whitelist (jpg, jpeg, png, gif, webp), and empty file validation. Added `MaxUploadSizeExceededException` handler.

## Test plan
- [ ] Verify JWT token generation/validation still works with existing secret
- [ ] Verify app fails to start if `JWT_SECRET` is shorter than 32 characters
- [ ] Trigger a server error and verify client only sees generic message
- [ ] Upload an image under 5MB → should succeed
- [ ] Upload a file over 5MB → should return 400 error
- [ ] Upload a non-image file (e.g., .exe renamed) → should be rejected
- [ ] Upload without Content-Type header → should return 400 error

Closes #12, closes #13, closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)